### PR TITLE
debug: refer to output facility as "serial port", not "terminal"

### DIFF
--- a/debug.asm
+++ b/debug.asm
@@ -1,6 +1,6 @@
 ; debug routines
 
-; print a string to the terminal
+; print a string to the serial port
 ; inputs:
 ; r0: pointer to null-terminated string
 ; outputs:


### PR DESCRIPTION
To avoid confusing it with the terminal application in fox32os.