### PR TITLE
Make use of data.strz

### DIFF
--- a/exception.asm
+++ b/exception.asm
@@ -581,37 +581,37 @@ system_breakpoint_handler:
     pop r31
     reti
 system_breakpoint_str:     data.str "Breakpoint reached!" data.8 10 data.8 0
-system_breakpoint_r0_str:  data.str "r0:  " data.8 0
-system_breakpoint_r1_str:  data.str "r1:  " data.8 0
-system_breakpoint_r2_str:  data.str "r2:  " data.8 0
-system_breakpoint_r3_str:  data.str "r3:  " data.8 0
-system_breakpoint_r4_str:  data.str "r4:  " data.8 0
-system_breakpoint_r5_str:  data.str "r5:  " data.8 0
-system_breakpoint_r6_str:  data.str "r6:  " data.8 0
-system_breakpoint_r7_str:  data.str "r7:  " data.8 0
-system_breakpoint_r8_str:  data.str "r8:  " data.8 0
-system_breakpoint_r9_str:  data.str "r9:  " data.8 0
-system_breakpoint_r10_str: data.str "r10: " data.8 0
-system_breakpoint_r11_str: data.str "r11: " data.8 0
-system_breakpoint_r12_str: data.str "r12: " data.8 0
-system_breakpoint_r13_str: data.str "r13: " data.8 0
-system_breakpoint_r14_str: data.str "r14: " data.8 0
-system_breakpoint_r15_str: data.str "r15: " data.8 0
-system_breakpoint_r16_str: data.str "r16: " data.8 0
-system_breakpoint_r17_str: data.str "r17: " data.8 0
-system_breakpoint_r18_str: data.str "r18: " data.8 0
-system_breakpoint_r19_str: data.str "r19: " data.8 0
-system_breakpoint_r20_str: data.str "r20: " data.8 0
-system_breakpoint_r21_str: data.str "r21: " data.8 0
-system_breakpoint_r22_str: data.str "r22: " data.8 0
-system_breakpoint_r23_str: data.str "r23: " data.8 0
-system_breakpoint_r24_str: data.str "r24: " data.8 0
-system_breakpoint_r25_str: data.str "r25: " data.8 0
-system_breakpoint_r26_str: data.str "r26: " data.8 0
-system_breakpoint_r27_str: data.str "r27: " data.8 0
-system_breakpoint_r28_str: data.str "r28: " data.8 0
-system_breakpoint_r29_str: data.str "r29: " data.8 0
-system_breakpoint_r30_str: data.str "r30: " data.8 0
-system_breakpoint_r31_str: data.str "r31: " data.8 0
-system_breakpoint_rsp_str: data.str "rsp: " data.8 0
-system_breakpoint_rip_str: data.str "rip: " data.8 0
+system_breakpoint_r0_str:  data.strz "r0:  "
+system_breakpoint_r1_str:  data.strz "r1:  "
+system_breakpoint_r2_str:  data.strz "r2:  "
+system_breakpoint_r3_str:  data.strz "r3:  "
+system_breakpoint_r4_str:  data.strz "r4:  "
+system_breakpoint_r5_str:  data.strz "r5:  "
+system_breakpoint_r6_str:  data.strz "r6:  "
+system_breakpoint_r7_str:  data.strz "r7:  "
+system_breakpoint_r8_str:  data.strz "r8:  "
+system_breakpoint_r9_str:  data.strz "r9:  "
+system_breakpoint_r10_str: data.strz "r10: "
+system_breakpoint_r11_str: data.strz "r11: "
+system_breakpoint_r12_str: data.strz "r12: "
+system_breakpoint_r13_str: data.strz "r13: "
+system_breakpoint_r14_str: data.strz "r14: "
+system_breakpoint_r15_str: data.strz "r15: "
+system_breakpoint_r16_str: data.strz "r16: "
+system_breakpoint_r17_str: data.strz "r17: "
+system_breakpoint_r18_str: data.strz "r18: "
+system_breakpoint_r19_str: data.strz "r19: "
+system_breakpoint_r20_str: data.strz "r20: "
+system_breakpoint_r21_str: data.strz "r21: "
+system_breakpoint_r22_str: data.strz "r22: "
+system_breakpoint_r23_str: data.strz "r23: "
+system_breakpoint_r24_str: data.strz "r24: "
+system_breakpoint_r25_str: data.strz "r25: "
+system_breakpoint_r26_str: data.strz "r26: "
+system_breakpoint_r27_str: data.strz "r27: "
+system_breakpoint_r28_str: data.strz "r28: "
+system_breakpoint_r29_str: data.strz "r29: "
+system_breakpoint_r30_str: data.strz "r30: "
+system_breakpoint_r31_str: data.strz "r31: "
+system_breakpoint_rsp_str: data.strz "rsp: "
+system_breakpoint_rip_str: data.strz "rip: "

--- a/main.asm
+++ b/main.asm
@@ -351,12 +351,12 @@ const MENU_POSITION_Y:      0x02156186 ; 2 bytes
 const MENU_FRAMEBUFFER_PTR: 0x0215618A ; 4 bytes
 const MENU_FRAMEBUFFER:     0x0215618E ; max 640x480x4 = end address at 0x0228218E
 
-startup_str_0: data.str "Welcome to fox32" data.8 0
-startup_str_1: data.str "Insert boot disk" data.8 0
+startup_str_0: data.strz "Welcome to fox32"
+startup_str_1: data.strz "Insert boot disk"
 
-bottom_bar_str_0: data.str "FOX" data.8 0
-bottom_bar_str_1: data.str "32" data.8 0
-bottom_bar_str_2: data.str " ROM version %u.%u.%u " data.8 0
+bottom_bar_str_0: data.strz "FOX"
+bottom_bar_str_1: data.strz "32"
+bottom_bar_str_2: data.strz " ROM version %u.%u.%u "
 bottom_bar_patterns:
     ; 1x16 tile
     data.32 0xFF674764

--- a/menu_bar.asm
+++ b/menu_bar.asm
@@ -249,25 +249,25 @@ menu_bar_click_event_end:
 ;    data.32 menu_items_edit_list   data.32 menu_items_edit_name   ; pointer to menu list, pointer to menu name
 ;    data.32 menu_items_system_list data.32 menu_items_system_name ; pointer to menu list, pointer to menu name
 ;menu_items_file_name:
-;    data.8 4 data.str "File" data.8 0x00   ; text length, text, null-terminator
+;    data.8 4 data.strz "File"   ; text length, text, null-terminator
 ;menu_items_file_list:
 ;    data.8 2                               ; number of items
 ;    data.8 6                               ; menu width (in number of characters)
-;    data.8 6 data.str "Test 1" data.8 0x00 ; text length, text, null-terminator
-;    data.8 6 data.str "Test 2" data.8 0x00 ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 1" ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 2" ; text length, text, null-terminator
 ;menu_items_edit_name:
-;    data.8 4 data.str "Edit" data.8 0x00   ; text length, text, null-terminator
+;    data.8 4 data.strz "Edit"   ; text length, text, null-terminator
 ;menu_items_edit_list:
 ;    data.8 2                               ; number of items
 ;    data.8 6                               ; menu width (in number of characters)
-;    data.8 6 data.str "Test 3" data.8 0x00 ; text length, text, null-terminator
-;    data.8 6 data.str "Test 4" data.8 0x00 ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 3" ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 4" ; text length, text, null-terminator
 ;menu_items_system_name:
-;    data.8 6 data.str "System" data.8 0x00 ; text length, text, null-terminator
+;    data.8 6 data.strz "System" ; text length, text, null-terminator
 ;menu_items_system_list:
 ;    data.8 4                               ; number of items
 ;    data.8 6                               ; menu width (in number of characters)
-;    data.8 6 data.str "Test 5" data.8 0x00 ; text length, text, null-terminator
-;    data.8 6 data.str "Test 6" data.8 0x00 ; text length, text, null-terminator
-;    data.8 6 data.str "Test 7" data.8 0x00 ; text length, text, null-terminator
-;    data.8 6 data.str "Test 8" data.8 0x00 ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 5" ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 6" ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 7" ; text length, text, null-terminator
+;    data.8 6 data.strz "Test 8" ; text length, text, null-terminator

--- a/monitor/commands/exit.asm
+++ b/monitor/commands/exit.asm
@@ -1,6 +1,6 @@
 ; exit command
 
-monitor_shell_exit_command_string: data.str "exit" data.8 0
+monitor_shell_exit_command_string: data.strz "exit"
 
 monitor_shell_exit_command:
     jmp exit_monitor

--- a/monitor/commands/help.asm
+++ b/monitor/commands/help.asm
@@ -1,6 +1,6 @@
 ; help command
 
-monitor_shell_help_command_string: data.str "help" data.8 0
+monitor_shell_help_command_string: data.strz "help"
 
 monitor_shell_help_command:
     mov r0, monitor_shell_help_text

--- a/monitor/commands/jump.asm
+++ b/monitor/commands/jump.asm
@@ -1,6 +1,6 @@
 ; jump command
 
-monitor_shell_jump_command_string: data.str "jump" data.8 0
+monitor_shell_jump_command_string: data.strz "jump"
 
 monitor_shell_jump_command:
     call monitor_shell_parse_arguments

--- a/monitor/commands/list.asm
+++ b/monitor/commands/list.asm
@@ -1,6 +1,6 @@
 ; list command
 
-monitor_shell_list_command_string: data.str "list" data.8 0
+monitor_shell_list_command_string: data.strz "list"
 
 monitor_shell_list_command:
     mov r0, monitor_shell_list_text

--- a/monitor/commands/set.asm
+++ b/monitor/commands/set.asm
@@ -1,8 +1,8 @@
 ; set command
 
-monitor_shell_set8_command_string:  data.str "set.8"  data.8 0
-monitor_shell_set16_command_string: data.str "set.16" data.8 0
-monitor_shell_set32_command_string: data.str "set.32" data.8 0
+monitor_shell_set8_command_string:  data.strz "set.8"
+monitor_shell_set16_command_string: data.strz "set.16"
+monitor_shell_set32_command_string: data.strz "set.32"
 
 monitor_shell_set8_command:
     call monitor_shell_parse_arguments

--- a/monitor/shell.asm
+++ b/monitor/shell.asm
@@ -233,4 +233,4 @@ const MONITOR_SHELL_TEXT_BUF_BOTTOM: 0x03ED3FE0 ; 32 characters
 const MONITOR_SHELL_TEXT_BUF_PTR:    0x03ED3FDC ; 4 bytes - pointer to the current input character
 const MONTIOR_SHELL_ARGS_PTR:        0x03ED36C5 ; 4 bytes - pointer to the beginning of the command arguments
 
-monitor_shell_prompt: data.str "> _" data.8 0
+monitor_shell_prompt: data.strz "> _"


### PR DESCRIPTION
The ROM is the same before and after this commit:

$ sha256sum fox32-orig.rom fox32.rom
75b169dafbf7dc77cd114f7d05d9c1e8459122bc2bd4178a90aba6fd8dc7372e  fox32-orig.rom 75b169dafbf7dc77cd114f7d05d9c1e8459122bc2bd4178a90aba6fd8dc7372e  fox32.rom


The conversion was performed with a few sed commands and manually unrolled in monitor/keyboard.asm:

find -name '*.asm' | xargs sed -i -e 's/data.str \("[^"]*"\) data.8 0$/data.strz \1/g' find -name '*.asm' | xargs sed -i -e 's/data.str \("[^"]*"\) data.8 0 /data.strz \1 /g' find -name '*.asm' | xargs sed -i -e 's/data.str \("[^"]*"\) data.8 0x00 /data.strz \1 /g'