### PR TITLE
Refactor system_breakpoint_handler and add 'reg' command to monitor

### DIFF
--- a/exception.asm
+++ b/exception.asm
@@ -41,12 +41,14 @@ system_page_fault_handler:
 system_page_fault_str: data.str "Page fault at virtual address r1" data.8 10 data.8 0
 
 ; called upon execution of a `brk` instruction
-; ensure the stack has at least 256 bytes of free space before triggering this exception!!
-; this code is extremely ugly, but it works :P
+; ensure the stack has at least 128 bytes of free space before triggering this exception!!
 system_breakpoint_handler:
     add rsp, 4
 
     ; push all registers once to save them
+    push rfp
+    push resp
+    push rsp
     push r31
     push r30
     push r29
@@ -80,470 +82,60 @@ system_breakpoint_handler:
     push r1
     push r0
 
-    ; then push all registers again so they can be popped one by one to print to the monitor
-    push r31
-    push r30
-    push r29
-    push r28
-    push r27
-    push r26
-    push r25
-    push r24
-    push r23
-    push r22
-    push r21
-    push r20
-    push r19
-    push r18
-    push r17
-    push r16
-    push r15
-    push r14
-    push r13
-    push r12
-    push r11
-    push r10
-    push r9
-    push r8
-    push r7
-    push r6
-    push r5
-    push r4
-    push r3
-    push r2
-    push r1
-    push r0
+    ; modify the saved rsp value to reflect the value of rsp before the
+    ; interrupt occured
+    ; resp (4) + rfp (4) + flags (1) + return address (4) = 13 bytes
+    add [rsp+128], 13
 
+    ; print breakpoint message
     mov r0, system_breakpoint_str
     call debug_print
     call print_string_to_monitor
 
-    ; r0
-    mov r0, system_breakpoint_r0_str
+    ; print the display containing all of the registers
+    ; r1 - used to store a pointer to the current string
+    ; r2 - stores the current address on the stack
+    ; r3 - loop counter
+    mov r1, system_breakpoint_r0_str
+    mov r2, rsp
+    mov r3, 0
+system_breakpoint_print_loop:
+    ; print the register label
+    mov r0, r1
     call print_string_to_monitor
-    pop r0
+    ; print the register value
+    mov r0, [r2]
     call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r1
-    mov r0, system_breakpoint_r1_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r2
-    mov r0, system_breakpoint_r2_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r3
-    mov r0, system_breakpoint_r3_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
+    ; adjust string pointer, stack address, and loop counter
+    add r1, SYSTEM_BREAKPOINT_R_STR_SIZE
+    inc r2, 4
+    inc r3
+    ; decide whether to print a separator or a newline by checking if the loop
+    ; counter is a multiple of 4
+    mov r0, r3
+    and r0, 0x03
+    ifnz jmp system_breakpoint_print_sep
+system_breakpoint_print_newline:
     mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; r4
-    mov r0, system_breakpoint_r4_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
+    jmp system_breakpoint_print_last_char
+system_breakpoint_print_sep:
     mov r0, ' '
     call print_character_to_monitor
     mov r0, '|'
     call print_character_to_monitor
     mov r0, ' '
-    call print_character_to_monitor
-
-    ; r5
-    mov r0, system_breakpoint_r5_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r6
-    mov r0, system_breakpoint_r6_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r7
-    mov r0, system_breakpoint_r7_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
-    mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; r8
-    mov r0, system_breakpoint_r8_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r9
-    mov r0, system_breakpoint_r9_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r10
-    mov r0, system_breakpoint_r10_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r11
-    mov r0, system_breakpoint_r11_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
-    mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; r12
-    mov r0, system_breakpoint_r12_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r13
-    mov r0, system_breakpoint_r13_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r14
-    mov r0, system_breakpoint_r14_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r15
-    mov r0, system_breakpoint_r15_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
-    mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; r16
-    mov r0, system_breakpoint_r16_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r17
-    mov r0, system_breakpoint_r17_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r18
-    mov r0, system_breakpoint_r18_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r19
-    mov r0, system_breakpoint_r19_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
-    mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; r20
-    mov r0, system_breakpoint_r20_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r21
-    mov r0, system_breakpoint_r21_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r22
-    mov r0, system_breakpoint_r22_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r23
-    mov r0, system_breakpoint_r23_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
-    mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; r24
-    mov r0, system_breakpoint_r24_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r25
-    mov r0, system_breakpoint_r25_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r26
-    mov r0, system_breakpoint_r26_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r27
-    mov r0, system_breakpoint_r27_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
-    mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; r28
-    mov r0, system_breakpoint_r28_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r29
-    mov r0, system_breakpoint_r29_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r30
-    mov r0, system_breakpoint_r30_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; r31
-    mov r0, system_breakpoint_r31_str
-    call print_string_to_monitor
-    pop r0
-    call print_hex_word_to_monitor
-
-    ; ---
-    mov r0, 10
-    call print_character_to_monitor
-    ; ---
-
-    ; rsp
-    mov r0, system_breakpoint_rsp_str
-    call print_string_to_monitor
-    mov r0, rsp
-    add r0, 133 ; account for the registers pushed above, and for the int calling convention
-    call print_hex_word_to_monitor
-
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-    call print_character_to_monitor
-
-    ; rip
+system_breakpoint_print_last_char:
+    call print_character_to_monitor
+    ; loop again if not on last register
+    cmp r3, 35
+    iflt jmp system_breakpoint_print_loop
+    ; print rip
     mov r0, system_breakpoint_rip_str
     call print_string_to_monitor
-    mov r0, rsp
-    add r0, 129 ; read instruction pointer from the stack
-    mov r0, [r0]
+    mov r0, [r2+1]
     call print_hex_word_to_monitor
-
-    ; ---
     mov r0, 10
     call print_character_to_monitor
-    ; ---
 
     call invoke_monitor
 
@@ -579,39 +171,46 @@ system_breakpoint_handler:
     pop r29
     pop r30
     pop r31
+    ; don't restore rsp and resp. not sure whether restoring a potentially
+    ; modified resp would break things, but changing rsp definitely would.
+    add rsp, 8
+    pop rfp
     reti
 system_breakpoint_str:     data.str "Breakpoint reached!" data.8 10 data.8 0
-system_breakpoint_r0_str:  data.strz "r0:  "
-system_breakpoint_r1_str:  data.strz "r1:  "
-system_breakpoint_r2_str:  data.strz "r2:  "
-system_breakpoint_r3_str:  data.strz "r3:  "
-system_breakpoint_r4_str:  data.strz "r4:  "
-system_breakpoint_r5_str:  data.strz "r5:  "
-system_breakpoint_r6_str:  data.strz "r6:  "
-system_breakpoint_r7_str:  data.strz "r7:  "
-system_breakpoint_r8_str:  data.strz "r8:  "
-system_breakpoint_r9_str:  data.strz "r9:  "
-system_breakpoint_r10_str: data.strz "r10: "
-system_breakpoint_r11_str: data.strz "r11: "
-system_breakpoint_r12_str: data.strz "r12: "
-system_breakpoint_r13_str: data.strz "r13: "
-system_breakpoint_r14_str: data.strz "r14: "
-system_breakpoint_r15_str: data.strz "r15: "
-system_breakpoint_r16_str: data.strz "r16: "
-system_breakpoint_r17_str: data.strz "r17: "
-system_breakpoint_r18_str: data.strz "r18: "
-system_breakpoint_r19_str: data.strz "r19: "
-system_breakpoint_r20_str: data.strz "r20: "
-system_breakpoint_r21_str: data.strz "r21: "
-system_breakpoint_r22_str: data.strz "r22: "
-system_breakpoint_r23_str: data.strz "r23: "
-system_breakpoint_r24_str: data.strz "r24: "
-system_breakpoint_r25_str: data.strz "r25: "
-system_breakpoint_r26_str: data.strz "r26: "
-system_breakpoint_r27_str: data.strz "r27: "
-system_breakpoint_r28_str: data.strz "r28: "
-system_breakpoint_r29_str: data.strz "r29: "
-system_breakpoint_r30_str: data.strz "r30: "
-system_breakpoint_r31_str: data.strz "r31: "
-system_breakpoint_rsp_str: data.strz "rsp: "
-system_breakpoint_rip_str: data.strz "rip: "
+const SYSTEM_BREAKPOINT_R_STR_SIZE: 7
+system_breakpoint_r0_str:  data.strz "r0:   "
+system_breakpoint_r1_str:  data.strz "r1:   "
+system_breakpoint_r2_str:  data.strz "r2:   "
+system_breakpoint_r3_str:  data.strz "r3:   "
+system_breakpoint_r4_str:  data.strz "r4:   "
+system_breakpoint_r5_str:  data.strz "r5:   "
+system_breakpoint_r6_str:  data.strz "r6:   "
+system_breakpoint_r7_str:  data.strz "r7:   "
+system_breakpoint_r8_str:  data.strz "r8:   "
+system_breakpoint_r9_str:  data.strz "r9:   "
+system_breakpoint_r10_str: data.strz "r10:  "
+system_breakpoint_r11_str: data.strz "r11:  "
+system_breakpoint_r12_str: data.strz "r12:  "
+system_breakpoint_r13_str: data.strz "r13:  "
+system_breakpoint_r14_str: data.strz "r14:  "
+system_breakpoint_r15_str: data.strz "r15:  "
+system_breakpoint_r16_str: data.strz "r16:  "
+system_breakpoint_r17_str: data.strz "r17:  "
+system_breakpoint_r18_str: data.strz "r18:  "
+system_breakpoint_r19_str: data.strz "r19:  "
+system_breakpoint_r20_str: data.strz "r20:  "
+system_breakpoint_r21_str: data.strz "r21:  "
+system_breakpoint_r22_str: data.strz "r22:  "
+system_breakpoint_r23_str: data.strz "r23:  "
+system_breakpoint_r24_str: data.strz "r24:  "
+system_breakpoint_r25_str: data.strz "r25:  "
+system_breakpoint_r26_str: data.strz "r26:  "
+system_breakpoint_r27_str: data.strz "r27:  "
+system_breakpoint_r28_str: data.strz "r28:  "
+system_breakpoint_r29_str: data.strz "r29:  "
+system_breakpoint_r30_str: data.strz "r30:  "
+system_breakpoint_r31_str: data.strz "r31:  "
+system_breakpoint_rsp_str: data.strz "rsp:  "
+system_breakpoint_resp_str: data.strz "resp: "
+system_breakpoint_rfp_str: data.strz "rfp:  "
+system_breakpoint_rip_str: data.strz "rip:  "

--- a/exception.asm
+++ b/exception.asm
@@ -92,51 +92,6 @@ system_breakpoint_handler:
     call debug_print
     call print_string_to_monitor
 
-    ; print the display containing all of the registers
-    ; r1 - used to store a pointer to the current string
-    ; r2 - stores the current address on the stack
-    ; r3 - loop counter
-    mov r1, system_breakpoint_r0_str
-    mov r2, rsp
-    mov r3, 0
-system_breakpoint_print_loop:
-    ; print the register label
-    mov r0, r1
-    call print_string_to_monitor
-    ; print the register value
-    mov r0, [r2]
-    call print_hex_word_to_monitor
-    ; adjust string pointer, stack address, and loop counter
-    add r1, SYSTEM_BREAKPOINT_R_STR_SIZE
-    inc r2, 4
-    inc r3
-    ; decide whether to print a separator or a newline by checking if the loop
-    ; counter is a multiple of 4
-    mov r0, r3
-    and r0, 0x03
-    ifnz jmp system_breakpoint_print_sep
-system_breakpoint_print_newline:
-    mov r0, 10
-    jmp system_breakpoint_print_last_char
-system_breakpoint_print_sep:
-    mov r0, ' '
-    call print_character_to_monitor
-    mov r0, '|'
-    call print_character_to_monitor
-    mov r0, ' '
-system_breakpoint_print_last_char:
-    call print_character_to_monitor
-    ; loop again if not on last register
-    cmp r3, 35
-    iflt jmp system_breakpoint_print_loop
-    ; print rip
-    mov r0, system_breakpoint_rip_str
-    call print_string_to_monitor
-    mov r0, [r2+1]
-    call print_hex_word_to_monitor
-    mov r0, 10
-    call print_character_to_monitor
-
     call invoke_monitor
 
     pop r0
@@ -177,40 +132,3 @@ system_breakpoint_print_last_char:
     pop rfp
     reti
 system_breakpoint_str:     data.str "Breakpoint reached!" data.8 10 data.8 0
-const SYSTEM_BREAKPOINT_R_STR_SIZE: 7
-system_breakpoint_r0_str:  data.strz "r0:   "
-system_breakpoint_r1_str:  data.strz "r1:   "
-system_breakpoint_r2_str:  data.strz "r2:   "
-system_breakpoint_r3_str:  data.strz "r3:   "
-system_breakpoint_r4_str:  data.strz "r4:   "
-system_breakpoint_r5_str:  data.strz "r5:   "
-system_breakpoint_r6_str:  data.strz "r6:   "
-system_breakpoint_r7_str:  data.strz "r7:   "
-system_breakpoint_r8_str:  data.strz "r8:   "
-system_breakpoint_r9_str:  data.strz "r9:   "
-system_breakpoint_r10_str: data.strz "r10:  "
-system_breakpoint_r11_str: data.strz "r11:  "
-system_breakpoint_r12_str: data.strz "r12:  "
-system_breakpoint_r13_str: data.strz "r13:  "
-system_breakpoint_r14_str: data.strz "r14:  "
-system_breakpoint_r15_str: data.strz "r15:  "
-system_breakpoint_r16_str: data.strz "r16:  "
-system_breakpoint_r17_str: data.strz "r17:  "
-system_breakpoint_r18_str: data.strz "r18:  "
-system_breakpoint_r19_str: data.strz "r19:  "
-system_breakpoint_r20_str: data.strz "r20:  "
-system_breakpoint_r21_str: data.strz "r21:  "
-system_breakpoint_r22_str: data.strz "r22:  "
-system_breakpoint_r23_str: data.strz "r23:  "
-system_breakpoint_r24_str: data.strz "r24:  "
-system_breakpoint_r25_str: data.strz "r25:  "
-system_breakpoint_r26_str: data.strz "r26:  "
-system_breakpoint_r27_str: data.strz "r27:  "
-system_breakpoint_r28_str: data.strz "r28:  "
-system_breakpoint_r29_str: data.strz "r29:  "
-system_breakpoint_r30_str: data.strz "r30:  "
-system_breakpoint_r31_str: data.strz "r31:  "
-system_breakpoint_rsp_str: data.strz "rsp:  "
-system_breakpoint_resp_str: data.strz "resp: "
-system_breakpoint_rfp_str: data.strz "rfp:  "
-system_breakpoint_rip_str: data.strz "rip:  "

--- a/keyboard.asm
+++ b/keyboard.asm
@@ -2,6 +2,10 @@
 
 ; add events to the event queue if a key was pressed or released
 ; this should only be called by system_vsync_handler
+; inputs:
+; none
+; outputs:
+; r0: non-zero if F12 was pressed, zero otherwise
 keyboard_update:
     ; pop a key from the keyboard queue
     in r0, 0x80000500
@@ -10,7 +14,7 @@ keyboard_update:
 
     ; invoke the debug monitor if F12 was pressed
     cmp r0, 0x58
-    ifz jmp invoke_monitor
+    ifz jmp keyboard_update_end
 
     ; check if this is a make or break scancode
     bts r0, 7
@@ -25,6 +29,7 @@ keyboard_update:
     mov r6, 0
     mov r7, 0
     call new_event
+    mov r0, 0
     jmp keyboard_update_end
 keyboard_update_break_scancode:
     and r0, 0x7F
@@ -37,5 +42,6 @@ keyboard_update_break_scancode:
     mov r6, 0
     mov r7, 0
     call new_event
+    mov r0, 0
 keyboard_update_end:
     ret

--- a/monitor/commands/commands.asm
+++ b/monitor/commands/commands.asm
@@ -29,6 +29,11 @@ monitor_shell_parse_command:
     call compare_string
     ifz jmp monitor_shell_load_command
 
+    ; reg
+    mov r1, monitor_shell_reg_command_string
+    call compare_string
+    ifz jmp monitor_shell_reg_command
+
     ; set.8
     mov r1, monitor_shell_set8_command_string
     call compare_string
@@ -59,4 +64,5 @@ monitor_shell_invalid_command_string: data.str "invalid command" data.8 10 data.
     #include "monitor/commands/jump.asm"
     #include "monitor/commands/list.asm"
     #include "monitor/commands/load.asm"
+    #include "monitor/commands/reg.asm"
     #include "monitor/commands/set.asm"

--- a/monitor/commands/help.asm
+++ b/monitor/commands/help.asm
@@ -16,5 +16,6 @@ monitor_shell_help_text:
     data.str "jump    | jump to address $0" data.8 10
     data.str "list    | list memory contents starting at address $0" data.8 10
     data.str "load    | load disk $0's sector $1 to buffer at address $2 of size $3 sectors" data.8 10
+    data.str "reg     | list contents of all registers" data.8 10
     data.str "set.SZ  | set [$0] to $1; equivalent to `mov.SZ [$0], $1`" data.8 10
     data.8 0

--- a/monitor/commands/reg.asm
+++ b/monitor/commands/reg.asm
@@ -1,0 +1,102 @@
+; reg command
+
+monitor_shell_reg_command_string: data.strz "reg"
+
+monitor_shell_reg_command:
+    push r0
+    push r1
+    push r2
+    push r3
+
+    ; print the display containing all of the registers
+    ; r1 - used to store a pointer to the current string
+    ; r2 - stores the current address on the stack
+    ; r3 - loop counter
+    mov r1, monitor_shell_reg_command_r0_str
+    mov r2, [MONITOR_OLD_RSP]
+    inc r2, 4
+    mov r3, 0
+monitor_shell_reg_command_print_loop:
+    ; print the register label
+    mov r0, r1
+    call print_string_to_monitor
+    ; print the register value
+    mov r0, [r2]
+    call print_hex_word_to_monitor
+    ; adjust string pointer, stack address, and loop counter
+    add r1, MONITOR_SHELL_COMMAND_R_STR_SIZE
+    inc r2, 4
+    inc r3
+    ; decide whether to print a separator or a newline by checking if the loop
+    ; counter is a multiple of 4
+    mov r0, r3
+    and r0, 0x03
+    ifnz jmp monitor_shell_reg_command_print_sep
+monitor_shell_reg_command_print_newline:
+    mov r0, 10
+    jmp monitor_shell_reg_command_print_last_char
+monitor_shell_reg_command_print_sep:
+    mov r0, ' '
+    call print_character_to_monitor
+    mov r0, '|'
+    call print_character_to_monitor
+    mov r0, ' '
+monitor_shell_reg_command_print_last_char:
+    call print_character_to_monitor
+    ; loop again if not on last register
+    cmp r3, 35
+    iflt jmp monitor_shell_reg_command_print_loop
+    ; print rip
+    mov r0, monitor_shell_reg_command_rip_str
+    call print_string_to_monitor
+    mov r0, [r2+1]
+    call print_hex_word_to_monitor
+    mov r0, 10
+    call print_character_to_monitor
+
+    call redraw_monitor_console
+
+    pop r3
+    pop r2
+    pop r1
+    pop r0
+
+    ret
+
+const MONITOR_SHELL_COMMAND_R_STR_SIZE: 7
+monitor_shell_reg_command_r0_str:  data.strz "r0:   "
+monitor_shell_reg_command_r1_str:  data.strz "r1:   "
+monitor_shell_reg_command_r2_str:  data.strz "r2:   "
+monitor_shell_reg_command_r3_str:  data.strz "r3:   "
+monitor_shell_reg_command_r4_str:  data.strz "r4:   "
+monitor_shell_reg_command_r5_str:  data.strz "r5:   "
+monitor_shell_reg_command_r6_str:  data.strz "r6:   "
+monitor_shell_reg_command_r7_str:  data.strz "r7:   "
+monitor_shell_reg_command_r8_str:  data.strz "r8:   "
+monitor_shell_reg_command_r9_str:  data.strz "r9:   "
+monitor_shell_reg_command_r10_str: data.strz "r10:  "
+monitor_shell_reg_command_r11_str: data.strz "r11:  "
+monitor_shell_reg_command_r12_str: data.strz "r12:  "
+monitor_shell_reg_command_r13_str: data.strz "r13:  "
+monitor_shell_reg_command_r14_str: data.strz "r14:  "
+monitor_shell_reg_command_r15_str: data.strz "r15:  "
+monitor_shell_reg_command_r16_str: data.strz "r16:  "
+monitor_shell_reg_command_r17_str: data.strz "r17:  "
+monitor_shell_reg_command_r18_str: data.strz "r18:  "
+monitor_shell_reg_command_r19_str: data.strz "r19:  "
+monitor_shell_reg_command_r20_str: data.strz "r20:  "
+monitor_shell_reg_command_r21_str: data.strz "r21:  "
+monitor_shell_reg_command_r22_str: data.strz "r22:  "
+monitor_shell_reg_command_r23_str: data.strz "r23:  "
+monitor_shell_reg_command_r24_str: data.strz "r24:  "
+monitor_shell_reg_command_r25_str: data.strz "r25:  "
+monitor_shell_reg_command_r26_str: data.strz "r26:  "
+monitor_shell_reg_command_r27_str: data.strz "r27:  "
+monitor_shell_reg_command_r28_str: data.strz "r28:  "
+monitor_shell_reg_command_r29_str: data.strz "r29:  "
+monitor_shell_reg_command_r30_str: data.strz "r30:  "
+monitor_shell_reg_command_r31_str: data.strz "r31:  "
+monitor_shell_reg_command_rsp_str: data.strz "rsp:  "
+monitor_shell_reg_command_resp_str: data.strz "resp: "
+monitor_shell_reg_command_rfp_str: data.strz "rfp:  "
+monitor_shell_reg_command_rip_str: data.strz "rip:  "

--- a/monitor/console.asm
+++ b/monitor/console.asm
@@ -38,7 +38,7 @@ print_hex_word_to_monitor_loop:
     add r12, r11
     movz.8 r0, [r12]
     call print_character_to_monitor
-    add r1, r6
+    ;add r1, r6
     loop print_hex_word_to_monitor_loop
 
     pop r31
@@ -67,7 +67,7 @@ print_hex_byte_to_monitor_loop:
     add r12, r11
     movz.8 r0, [r12]
     call print_character_to_monitor
-    add r1, r6
+    ;add r1, r6
     loop print_hex_byte_to_monitor_loop
 
     pop r31

--- a/monitor/monitor.asm
+++ b/monitor/monitor.asm
@@ -1,42 +1,10 @@
 ; debug monitor
 
+; only call this from system_breakpoint_handler!
 invoke_monitor:
     ; return if we're already in the monitor
     cmp [0x000003FC], monitor_vsync_handler
     ifz jmp invoke_monitor_aleady_in_monitor
-
-    push r31
-    push r30
-    push r29
-    push r28
-    push r27
-    push r26
-    push r25
-    push r24
-    push r23
-    push r22
-    push r21
-    push r20
-    push r19
-    push r18
-    push r17
-    push r16
-    push r15
-    push r14
-    push r13
-    push r12
-    push r11
-    push r10
-    push r9
-    push r8
-    push r7
-    push r6
-    push r5
-    push r4
-    push r3
-    push r2
-    push r1
-    push r0
 
     ; set the vsync handler to our own and reenable interrupts
     mov [MONITOR_OLD_VSYNC_HANDLER], [0x000003FC]
@@ -94,39 +62,6 @@ exit_monitor:
 
     call enable_cursor
 
-    pop r0
-    pop r1
-    pop r2
-    pop r3
-    pop r4
-    pop r5
-    pop r6
-    pop r7
-    pop r8
-    pop r9
-    pop r10
-    pop r11
-    pop r12
-    pop r13
-    pop r14
-    pop r15
-    pop r16
-    pop r17
-    pop r18
-    pop r19
-    pop r20
-    pop r21
-    pop r22
-    pop r23
-    pop r24
-    pop r25
-    pop r26
-    pop r27
-    pop r28
-    pop r29
-    pop r30
-    pop r31
-
     ret
 
 exit_monitor_and_jump:
@@ -139,39 +74,6 @@ exit_monitor_and_jump:
 
     ; save the jump address in a temporary location
     mov [MONITOR_OLD_RSP], r0
-
-    pop r0
-    pop r1
-    pop r2
-    pop r3
-    pop r4
-    pop r5
-    pop r6
-    pop r7
-    pop r8
-    pop r9
-    pop r10
-    pop r11
-    pop r12
-    pop r13
-    pop r14
-    pop r15
-    pop r16
-    pop r17
-    pop r18
-    pop r19
-    pop r20
-    pop r21
-    pop r22
-    pop r23
-    pop r24
-    pop r25
-    pop r26
-    pop r27
-    pop r28
-    pop r29
-    pop r30
-    pop r31
 
     jmp [MONITOR_OLD_RSP]
 

--- a/vsync.asm
+++ b/vsync.asm
@@ -15,6 +15,9 @@ system_vsync_handler:
     call keyboard_update
     cmp.8 [UPDATE_ICON], 0
     ifnz call icon_update
+    ; check if monitor should be started
+    cmp r0, 0
+    ifnz jmp system_vsync_handler_breakpoint
 
     pop r7
     pop r6
@@ -25,3 +28,16 @@ system_vsync_handler:
     pop r1
     pop r0
     reti
+
+system_vsync_handler_breakpoint:
+    pop r7
+    pop r6
+    pop r5
+    pop r4
+    pop r3
+    pop r2
+    pop r1
+    pop r0
+    ; breakpoint handler expects that there is an extra 4 bytes on the stack
+    sub rsp, 4
+    jmp system_breakpoint_handler


### PR DESCRIPTION
This PR almost completely rewrites system_breakpoint_handler, and changes the way opening the ROM monitor works. Previously, the ROM monitor was handled as a subroutine that could be called from any interrupt. Now, the monitor is only directly invoked from system_breakpoint_handler, making its environment more predictable, and as a result, giving it increased access to the system state, such as the registers saved on the stack. system_vsync_handler and keyboard_update have been modified to transfer control to the breakpoint handler, rather than running the monitor as a subroutine. The register printing functionality that was previously in system_breakpoint_handler has been completely rewritten, and is now part of a new monitor command called 'reg'.