### PR TITLE
Add breakpoint commands to ROM monitor

### DIFF
--- a/main.asm
+++ b/main.asm
@@ -62,6 +62,8 @@ entry_seed_done:
     ; initialize the monitor X and Y coordinates
     mov.8 [MONITOR_CONSOLE_X], 0
     mov.8 [MONITOR_CONSOLE_Y], 28
+    ; initialize the breakpoint table
+    call monitor_breakpoint_init
 
     ; enable interrupts
     ise

--- a/monitor/breakpoint.asm
+++ b/monitor/breakpoint.asm
@@ -14,9 +14,11 @@
 monitor_breakpoint_add:
     ; check if the address is a valid location for a breakpoint
     ; if the address is not in RAM, a breakpoint cannot be added
-    cmp r0, 0x04000000
-    ifgteq mov r0, 0xFFFFFFFF
-    ifgteq ret
+    ; (maximum possible address is 0x03fffffe, because the brk opcode is two
+    ; bytes)
+    cmp r0, 0x03fffffe
+    ifgt mov r0, 0xFFFFFFFF
+    ifgt ret
     ; check if breakpoint is already defined at this address, and fail if so
     push r1
     mov r1, r0

--- a/monitor/breakpoint.asm
+++ b/monitor/breakpoint.asm
@@ -1,0 +1,255 @@
+; debug breakpoint handling routines
+
+; set a breakpoint at at particular address, using a specific slot in the
+; breakpoint table. does nothing if there is already a breakpoint set at this
+; address. if this slot is already occupied, that breakpoint will be removed
+; before the new one is added.
+; inputs:
+; r0: address at which to set breakpoint
+; r1: breakpoint number
+; outputs:
+; r0: if a breakpoint was removed, the address of that breakpoint;
+;     0 if no breakpoint was removed to add this breakpoint;
+;     -1 if the breakpoint could not be added
+monitor_breakpoint_add:
+    ; check if the address is a valid location for a breakpoint
+    ; if the address is not in RAM, a breakpoint cannot be added
+    cmp r0, 0x04000000
+    ifgteq mov r0, 0xFFFFFFFF
+    ifgteq ret
+    ; check if breakpoint is already defined at this address, and fail if so
+    push r1
+    mov r1, r0
+    call monitor_breakpoint_find_addr
+    cmp r0, 0xffffffff
+    ifnz jmp monitor_breakpoint_add_addr_check_fail
+    ; check if breakpoint is already defined at one address below this
+    ; address, and fail if so
+    mov r0, r1
+    dec r0
+    call monitor_breakpoint_find_addr
+    cmp r0, 0xffffffff
+    ifnz jmp monitor_breakpoint_add_addr_check_fail
+    ; check if breakpoint is already defined at one address above this
+    ; address, and fail if so
+    mov r0, r1
+    inc r0
+    call monitor_breakpoint_find_addr
+    cmp r0, 0xffffffff
+    ifnz jmp monitor_breakpoint_add_addr_check_fail
+    mov r0, r1
+    pop r1
+    ; check if the breakpoint number is valid, and if not, return
+    cmp r1, 0x10
+    ifgteq mov r0, 0xFFFFFFFF
+    ifgteq ret
+
+    push r1
+    push r2
+    push r3
+    push r4
+    ; clear r4 to indicate no breakpoint removed
+    mov r4, 0
+    ; get offset into saved instruction table in r3
+    mov r2, r1
+    sla r2, 1
+    mov r3, r2
+    ; get offset into breakpoint table in r2
+    sla r2, 1
+    ; add base addresses of tables
+    add r2, MONITOR_BREAKPOINT_TABLE
+    add r3, MONITOR_SAVED_INSTR_TABLE
+    ; check if breakpoint is currently set, and if so, remove it
+    cmp [r2], 0
+    ifz jmp monitor_breakpoint_add_skip_rm
+    ; remove the breakpoint occupying the slot
+    push r0
+    mov r0, r1
+    call monitor_breakpoint_remove
+    ; store its address in r4
+    mov r4, r0
+    pop r0
+monitor_breakpoint_add_skip_rm:
+    ; save current contents of breakpoint location
+    mov.16 [r3], [r0]
+    ; place break instruction at the address
+    mov.16 [r0], MONITOR_BREAKPOINT_BRK_INSTR
+    ; save address in table
+    mov [r2], r0
+    ; return the address of the removed breakpoint (if any)
+    mov r0, r4
+    
+    pop r4
+    pop r3
+    pop r2
+    pop r1
+    ret
+monitor_breakpoint_add_addr_check_fail:
+    pop r1
+    mov r0, 0xffffffff
+    ret
+
+; set a breakpoint at a particular address, using the first available slot in
+; the breakpoint table. does nothing if there are no available slots.
+; inputs:
+; r0: address at which to set breakpoint
+; outputs:
+; r0: the number of the set breakpoint; -1 if no breakpoint was set
+monitor_breakpoint_add_any:
+    push r1
+    mov r1, r0
+    ; get the first available slot in the breakpoint table
+    mov r0, 0
+    call monitor_breakpoint_find_addr
+    ; if the breakpoint number is -1, return
+    cmp r0, 0x10
+    ifgteq jmp monitor_breakpoint_add_any_ret
+    ; swap r1 and r0
+    push r0
+    mov r0, r1
+    pop r1
+    ; set the breakpoint
+    call monitor_breakpoint_add
+    ; if r0 is -1, the breakpoint could not be added, so return
+    cmp r0, 0xFFFFFFFF
+    ifz jmp monitor_breakpoint_add_any_ret
+    ; get breakpoint number in r0
+    mov r0, r1
+monitor_breakpoint_add_any_ret:
+    pop r1
+    ret
+
+; remove a breakpoint. does nothing if that breakpoint number is not set.
+; inputs:
+; r0: the breakpoint number to remove
+; outputs:
+; r0: the address of the removed breakpoint; zero if the breakpoint was not
+;     set
+monitor_breakpoint_remove:
+    ; if breakpoint number is out of range, return immediately
+    cmp r0, 0x10
+    ifgteq ret
+    push r1
+    push r2
+    ; get offset into saved instruction table in r1
+    sla r0, 1
+    mov r1, r0
+    ; get offset into breakpoint table in r0
+    sla r0, 1
+    ; add base addresses of tables
+    add r0, MONITOR_BREAKPOINT_TABLE
+    add r1, MONITOR_SAVED_INSTR_TABLE
+    ; get breakpoint address in r2
+    mov r2, [r0]
+    ; if breakpoint address is zero, return
+    cmp r2, 0
+    ifz jmp monitor_breakpoint_remove_ret
+    ; clear address in table
+    mov [r0], 0
+    ; restore original instruction
+    mov.16 [r2], [r1]
+monitor_breakpoint_remove_ret:
+    ; copy breakpoint address into r0
+    mov r0, r2
+
+    pop r2
+    pop r1
+    ret
+
+; remove a breakpoint at a particular address. does nothing if there is no
+; breakpoint at that address.
+; inputs:
+; r0: address to remove breakpoint from
+; outputs:
+; r0: number of the breakpoint that was removed; -1 if no breakpoint was
+;     removed
+monitor_breakpoint_remove_addr:
+    ; get the breakpoint number corresponding to the address
+    call monitor_breakpoint_find_addr
+    ; check if breakpoint number is -1, and if so, return it
+    cmp r0, 0x10
+    ifgteq ret
+    
+    push r0
+    call monitor_breakpoint_remove
+    pop r0
+    ret
+
+; get the first occurence of a particular address in the breakpoint table.
+; can be used with zero to find the first unused entry.
+; inputs:
+; r0: the address to search for
+; outputs:
+; r0: the number of the first matching breakpoint; -1 if no match is found
+monitor_breakpoint_find_addr:
+    push r1
+    push r2
+    ; initialize registers before loop
+    mov r2, r0
+    mov r0, 0
+    mov r1, MONITOR_BREAKPOINT_TABLE
+monitor_breakpoint_find_addr_loop:
+    ; check if this table entry matches
+    cmp [r1], r2
+    ifz jmp monitor_breakpoint_find_addr_found
+    ; increment loop registers
+    inc r0
+    inc r1, 4
+    ; check if the current breakpoint number is within range (< 0x10)
+    cmp r0, 0x10
+    iflt jmp monitor_breakpoint_find_addr_loop
+    ; otherwise, there is no matching breakpoint slot, so return -1
+    mov r0, 0xFFFFFFFF
+monitor_breakpoint_find_addr_found:
+    pop r2
+    pop r1
+    ret
+
+; called when the monitor starts; checks if a breakpoint needs to be removed
+monitor_breakpoint_update:
+    ; get the ip when the breakpoint occurred
+    mov r2, [MONITOR_OLD_RSP]
+    ;   4 byte monitor return address
+    ; + 140 = 4 bytes * 35 saved registers
+    ; + 1 byte of flags
+    ; = 145 bytes to reach saved rip
+    add r2, 145
+    mov r1, [r2]
+    ; adjust it to point to the brk instruction itself
+    dec r1, 2
+    ; is there a matching breakpoint in the table? if not, simply return
+    mov r0, r1
+    call monitor_breakpoint_find_addr
+    cmp r0, 0xFFFFFFFF
+    ifz ret
+    ; if so, remove the breakpoint, and write the adjusted rip back to the
+    ; stack
+    call monitor_breakpoint_remove
+    mov [r2], r1
+    ret
+
+; called to initialize the breakpoint state when the machine starts
+monitor_breakpoint_init:
+    push r0
+    push r1
+    ; zero the breakpoint table
+    mov r0, MONITOR_BREAKPOINT_TABLE
+    mov r1, 0
+monitor_breakpoint_init_loop:
+    mov [r0], 0
+    inc r0, 4
+    inc r1
+    cmp r1, 32
+    iflt jmp monitor_breakpoint_init_loop
+    pop r1
+    pop r0
+    ret
+
+    
+
+; breakpoint table; contains the addresses of breakpoints
+; zero indicates an unused entry
+const MONITOR_BREAKPOINT_TABLE:     0x03ED367D ; 64 bytes
+const MONITOR_SAVED_INSTR_TABLE:    0x03ED365D ; 32 bytes
+
+const MONITOR_BREAKPOINT_BRK_INSTR: 0xA000

--- a/monitor/commands/brk.asm
+++ b/monitor/commands/brk.asm
@@ -161,12 +161,14 @@ monitor_shell_brk_command_print_fail_msg:
     push r0
     mov r0, monitor_shell_brk_command_fail_str
     call print_string_to_monitor
+    mov r0, ' '
+    call print_character_to_monitor
     pop r0
     call monitor_shell_brk_command_print_num_at_addr
     ret
 
 ; print a message stating that the breakpoint couldn't be added
-; 'Failed to add breakpoint  at XXXXXXXX'
+; 'Failed to add breakpoint at XXXXXXXX'
 ; inputs:
 ; r0: address of breakpoint
 ; r1: breakpoint number
@@ -228,7 +230,7 @@ monitor_shell_brk_command_print_num_at_addr:
 monitor_shell_brk_command_add_str:
     data.strz "Added breakpoint "
 monitor_shell_brk_command_fail_str:
-    data.strz "Failed to add breakpoint "
+    data.strz "Failed to add breakpoint"
 monitor_shell_brk_command_invalid_str:
     data.strz "Invalid breakpoint number "
 monitor_shell_brk_command_at_str:

--- a/monitor/commands/brk.asm
+++ b/monitor/commands/brk.asm
@@ -1,0 +1,237 @@
+; brk command
+
+monitor_shell_brk_command_string: data.strz "brk"
+
+monitor_shell_brk_command:
+    ; push an extra return to redraw the console
+    push redraw_monitor_console
+    call monitor_shell_parse_arguments
+
+    ; arguments:
+    ; $0: address to set breakpoint at (optional)
+    ; $1: breakpoint number (optional)
+    ; if $1 is omitted, set breakpoint using first available number
+    ; if $0 is omitted, list current breakpoints
+
+    ; check if argument $0 is empty
+    cmp r0, 0
+    ifz jmp monitor_shell_brk_command_list
+    ; if not, convert it to integer
+    push r1
+    mov r1, 16
+    call string_to_int
+    mov r10, r0
+
+    ; check if argument $1 is empty
+    pop r0
+    cmp r0, 0
+    ifz jmp monitor_shell_brk_command_add_any
+    ; if not, convert it to integer
+    call string_to_int
+    mov r11, r0
+
+monitor_shell_brk_command_add:
+    ; check if breakpoint number is valid
+    cmp r11, 0x10
+    ifgteq jmp monitor_shell_brk_command_add_invalid_num
+    ; add the breakpoint
+    mov r0, r10
+    mov r1, r11
+    call monitor_breakpoint_add
+    ; check if adding the breakpoint failed
+    cmp r0, 0xFFFFFFFF
+    ifz jmp monitor_shell_brk_command_add_fail
+    ; check if a breakpoint was removed to add this one, and if so, display
+    ; a message
+    cmp r0, 0
+    ifnz call monitor_shell_brkrm_command_print_rm_msg
+    ; display a message that a breakpoint was added
+    mov r0, r10
+    mov r1, r11
+    call monitor_shell_brk_command_print_add_msg
+
+    ret
+
+monitor_shell_brk_command_add_fail:
+    ; print failure message
+    mov r0, r10
+    mov r1, r11
+    call monitor_shell_brk_command_print_fail_msg
+
+    ret
+
+monitor_shell_brk_command_add_invalid_num:
+    ; print failure message
+    mov r0, r11
+    call monitor_shell_brk_command_print_invalid_msg
+
+    ret
+
+monitor_shell_brk_command_add_any:
+    ; add the breakpoint
+    mov r0, r10
+    call monitor_breakpoint_add_any
+    ; check if adding the breakpoint failed
+    cmp r0, 0xFFFFFFFF
+    ifz jmp monitor_shell_brk_command_add_any_fail
+    ; display a message that the breakpoint was added
+    mov r1, r0
+    mov r0, r10
+    call monitor_shell_brk_command_print_add_msg
+
+    ret
+
+monitor_shell_brk_command_add_any_fail:
+    ; print failure message
+    mov r0, r10
+    call monitor_shell_brk_command_print_fail_msg_no_num
+
+    ret
+
+monitor_shell_brk_command_list:
+    ; get breakpoint number in r1 and table pointer in r2
+    mov r1, 0
+    mov r2, MONITOR_BREAKPOINT_TABLE
+    ; loop over each table entry
+monitor_shell_brk_command_list_loop:
+    ; print breakpoint number and address
+    mov r0, r1
+    call print_hex_digit_to_monitor
+    mov r0, ':'
+    call print_character_to_monitor
+    mov r0, ' '
+    call print_character_to_monitor
+    ; check whether breakpoint is set
+    mov r0, [r2]
+    cmp r0, 0
+    ifnz jmp monitor_shell_brk_command_list_print_addr
+    ; breakpoint is not set, so print dashes instead of address
+    mov r0, monitor_shell_brk_command_unset_str
+    call print_string_to_monitor
+    jmp monitor_shell_brk_command_list_print_addr_done
+monitor_shell_brk_command_list_print_addr:
+    ; breakpoint is set, so print its address
+    call print_hex_word_to_monitor
+monitor_shell_brk_command_list_print_addr_done:
+    ; increment breakpoint number and table pointer
+    inc r1
+    inc r2, 4
+    ; if new breakpoint number is a multiple of 4, only print a newline
+    mov r0, r1
+    and r0, 0x03
+    ifz mov r0, 10
+    ifz jmp monitor_shell_brk_command_list_print_last
+    ; print separator
+    mov r0, ' '
+    call print_character_to_monitor
+    mov r0, '|'
+    call print_character_to_monitor
+    mov r0, ' '
+monitor_shell_brk_command_list_print_last:
+    call print_character_to_monitor
+    ; loop again if new breakpoint number is in range
+    cmp r1, 0x10
+    iflt jmp monitor_shell_brk_command_list_loop
+
+    ret
+
+; print a message stating that the breakpoint was added
+; 'Added breakpoint X at XXXXXXXX'
+; inputs:
+; r0: address of breakpoint
+; r1: breakpoint number
+; outputs:
+; none
+monitor_shell_brk_command_print_add_msg:
+    push r0
+    mov r0, monitor_shell_brk_command_add_str
+    call print_string_to_monitor
+    pop r0
+    call monitor_shell_brk_command_print_num_at_addr
+    ret
+
+; print a message stating that the breakpoint couldn't be added
+; 'Failed to add breakpoint X at XXXXXXXX'
+; inputs:
+; r0: address of breakpoint
+; r1: breakpoint number
+; outputs:
+; none
+monitor_shell_brk_command_print_fail_msg:
+    push r0
+    mov r0, monitor_shell_brk_command_fail_str
+    call print_string_to_monitor
+    pop r0
+    call monitor_shell_brk_command_print_num_at_addr
+    ret
+
+; print a message stating that the breakpoint couldn't be added
+; 'Failed to add breakpoint  at XXXXXXXX'
+; inputs:
+; r0: address of breakpoint
+; r1: breakpoint number
+; outputs:
+; none
+monitor_shell_brk_command_print_fail_msg_no_num:
+    push r0
+    push r0
+    mov r0, monitor_shell_brk_command_fail_str
+    call print_string_to_monitor
+    mov r0, monitor_shell_brk_command_at_str
+    call print_string_to_monitor
+    pop r0
+    call print_hex_word_to_monitor
+    mov r0, 10
+    call print_character_to_monitor
+    pop r0
+    ret
+
+; print a message that the provided breakpoint number is invalid
+; 'Invalid breakpoint number XXXXXXXX'
+; inputs:
+; r0: breakpoint number
+; outputs:
+; none
+monitor_shell_brk_command_print_invalid_msg:
+    push r0
+    push r0
+    mov r0, monitor_shell_brk_command_invalid_str
+    call print_string_to_monitor
+    pop r0
+    call print_hex_word_to_monitor
+    mov r0, 10
+    call print_character_to_monitor
+    pop r0
+    ret
+
+; print the breakpoint number, followed by ' at ', followed by its address,
+; followed by a newline
+; inputs:
+; r0: address of breakpoint
+; r1: breakpoint number
+; outputs:
+; none
+monitor_shell_brk_command_print_num_at_addr:
+    push r0
+    push r0
+    mov r0, r1
+    call print_hex_digit_to_monitor
+    mov r0, monitor_shell_brk_command_at_str
+    call print_string_to_monitor
+    pop r0
+    call print_hex_word_to_monitor
+    mov r0, 10
+    call print_character_to_monitor
+    pop r0
+    ret
+
+monitor_shell_brk_command_add_str:
+    data.strz "Added breakpoint "
+monitor_shell_brk_command_fail_str:
+    data.strz "Failed to add breakpoint "
+monitor_shell_brk_command_invalid_str:
+    data.strz "Invalid breakpoint number "
+monitor_shell_brk_command_at_str:
+    data.strz " at "
+monitor_shell_brk_command_unset_str:
+    data.strz "--------"

--- a/monitor/commands/brkrm.asm
+++ b/monitor/commands/brkrm.asm
@@ -1,0 +1,80 @@
+; brkrm command
+
+monitor_shell_brkrm_command_string: data.strz "brkrm"
+
+monitor_shell_brkrm_command:
+    ; push an extra return to redraw the console
+    push redraw_monitor_console
+    call monitor_shell_parse_arguments
+
+    ; arguments:
+    ; $0: number of breakpoint to be removed
+
+    ; check if argument $0 is empty
+    cmp r0, 0
+    ifz jmp monitor_shell_brkrm_command_missing_arg
+    ; if not, convert it to integer
+    mov r1, 16
+    call string_to_int
+    mov r10, r0
+
+    ; make sure the breakpoint number is in range
+    cmp r10, 0x10
+    ifgteq jmp monitor_shell_brkrm_command_invalid_num
+
+    ; remove the breakpoint
+    call monitor_breakpoint_remove
+    ; determine whether a breakpoint was removed
+    cmp r0, 0
+    ifz jmp monitor_shell_brkrm_command_not_set
+    ; breakpoint was set, so print removal message
+    mov r1, r10
+    call monitor_shell_brkrm_command_print_rm_msg
+    ret
+
+monitor_shell_brkrm_command_not_set:
+    ; breakpoint was not set, so print the corresponding message
+    mov r0, monitor_shell_brkrm_command_not_set_msg_1
+    call print_string_to_monitor
+    mov r0, r10
+    call print_hex_digit_to_monitor
+    mov r0, monitor_shell_brkrm_command_not_set_msg_2
+    call print_string_to_monitor
+    ret
+
+monitor_shell_brkrm_command_invalid_num:
+    ; print a message indicating that the breakpoint number is invalid
+    mov r0, r10
+    call monitor_shell_brk_command_print_invalid_msg
+    ret
+
+monitor_shell_brkrm_command_missing_arg:
+    ; print a message indicating that an argument is missing
+    mov r0, monitor_shell_brkrm_command_missing_arg_msg
+    call print_string_to_monitor
+    ret
+
+; print a message stating that the breakpoint was removed
+; 'Removed breakpoint X at XXXXXXXX'
+; inputs:
+; r0: address of breakpoint
+; r1: breakpoint number
+; outputs:
+; none
+monitor_shell_brkrm_command_print_rm_msg:
+    push r0
+    mov r0, monitor_shell_brkrm_command_rm_str
+    call print_string_to_monitor
+    pop r0
+    call monitor_shell_brk_command_print_num_at_addr
+    ret
+
+monitor_shell_brkrm_command_rm_str:
+    data.strz "Removed breakpoint "
+monitor_shell_brkrm_command_missing_arg_msg:
+    data.str "Missing argument $0; breakpoint number is required"
+    data.8 10 data.8 0
+monitor_shell_brkrm_command_not_set_msg_1:
+    data.strz "Breakpoint "
+monitor_shell_brkrm_command_not_set_msg_2:
+    data.str " not set" data.8 10 data.8 0

--- a/monitor/commands/commands.asm
+++ b/monitor/commands/commands.asm
@@ -1,5 +1,7 @@
 ; command parser
 
+; TODO: all commands need to check for invalid arguments
+
 monitor_shell_parse_command:
     mov r0, MONITOR_SHELL_TEXT_BUF_BOTTOM
 
@@ -24,6 +26,10 @@ monitor_shell_parse_command_loop:
     ret
 
 monitor_shell_command_table:
+    data.32 monitor_shell_brk_command_string
+    data.32 monitor_shell_brk_command
+    data.32 monitor_shell_brkrm_command_string
+    data.32 monitor_shell_brkrm_command
     data.32 monitor_shell_exit_command_string
     data.32 monitor_shell_exit_command
     data.32 monitor_shell_help_command_string
@@ -46,6 +52,8 @@ monitor_shell_command_table:
 monitor_shell_invalid_command_string: data.str "invalid command" data.8 10 data.8 0
 
     ; all commands
+    #include "monitor/commands/brk.asm"
+    #include "monitor/commands/brkrm.asm"
     #include "monitor/commands/exit.asm"
     #include "monitor/commands/help.asm"
     #include "monitor/commands/jump.asm"

--- a/monitor/commands/commands.asm
+++ b/monitor/commands/commands.asm
@@ -3,6 +3,10 @@
 ; TODO: all commands need to check for invalid arguments
 
 monitor_shell_parse_command:
+    ; push the address of monitor_breakpoint_update to the stack so that it
+    ; will be called as soon as the command returns
+    push monitor_breakpoint_update
+
     mov r0, MONITOR_SHELL_TEXT_BUF_BOTTOM
 
     ; loop over the table of commands

--- a/monitor/commands/help.asm
+++ b/monitor/commands/help.asm
@@ -11,6 +11,9 @@ monitor_shell_help_command:
 monitor_shell_help_text:
     data.str "command | description" data.8 10
     data.str "------- | -----------" data.8 10
+    data.str "brk     | add breakpoint $1 (optional) at address $0;" data.8 10
+    data.str "        | list breakpoints if no arguments provided" data.8 10
+    data.str "brkrm   | remove breakpoint $0" data.8 10
     data.str "exit    | exit the monitor" data.8 10
     data.str "help    | display this help text" data.8 10
     data.str "jump    | jump to address $0" data.8 10

--- a/monitor/console.asm
+++ b/monitor/console.asm
@@ -76,6 +76,23 @@ print_hex_byte_to_monitor_loop:
     pop r10
     ret
 
+; print a hex digit to the monitor
+; inputs:
+; r0: number of digit to print
+; outputs:
+; none
+print_hex_digit_to_monitor:
+    push r0
+    push r1
+    cmp r0, 0x0a
+    iflt mov r1, '0'
+    ifgteq mov r1, '7' ; '7' = 'A' - 10
+    add r0, r1
+    call print_character_to_monitor
+    pop r1
+    pop r0
+    ret
+
 ; print a single character to the monitor
 ; inputs:
 ; r0: character

--- a/monitor/monitor.asm
+++ b/monitor/monitor.asm
@@ -54,6 +54,7 @@ invoke_monitor:
     call redraw_monitor_console
 
     mov [MONITOR_OLD_RSP], rsp
+    call monitor_breakpoint_update
     jmp monitor_shell_start
 exit_monitor:
     ; restore the old RSP and vsync handler, reset the cursor, and exit
@@ -83,6 +84,7 @@ invoke_monitor_aleady_in_monitor:
 
 info_str: data.str "fox32rom monitor" data.8 0x00
 
+    #include "monitor/breakpoint.asm"
     #include "monitor/commands/commands.asm"
     #include "monitor/console.asm"
     #include "monitor/keyboard.asm"


### PR DESCRIPTION
This PR adds the `brk` and `brkrm` commands to the ROM monitor, which allow breakpoints to be viewed, added, and removed.