### PR TITLE
`keyboard_update` now exhausts keyboard queue

### DIFF
--- a/keyboard.asm
+++ b/keyboard.asm
@@ -8,20 +8,23 @@
 ; r0: non-zero if F12 was pressed, zero otherwise
 keyboard_update:
     ; pop a key from the keyboard queue
-    in r0, 0x80000500
-    cmp r0, 0
-    ifz jmp keyboard_update_end
+    in r1, 0x80000500
+
+    ; no key event
+    cmp r1, 0
+    ifz mov r0, 0
+    ifz ret
 
     ; invoke the debug monitor if F12 was pressed
-    cmp r0, 0x58
-    ifz jmp keyboard_update_end
+    cmp r1, 0x58
+    ifz mov r0, 1
+    ifz ret
 
-    ; check if this is a make or break scancode
-    bts r0, 7
-    ifnz jmp keyboard_update_break_scancode
-
-    mov r1, r0
-    mov r0, EVENT_TYPE_KEY_DOWN
+    ; check if this is a key up or key down scancode
+    bts r1, 7
+    ifz mov r0, EVENT_TYPE_KEY_DOWN
+    ifnz mov r0, EVENT_TYPE_KEY_UP
+    ifnz and r1, 0x7F
     mov r2, 0
     mov r3, 0
     mov r4, 0
@@ -29,19 +32,4 @@ keyboard_update:
     mov r6, 0
     mov r7, 0
     call new_event
-    mov r0, 0
-    jmp keyboard_update_end
-keyboard_update_break_scancode:
-    and r0, 0x7F
-    mov r1, r0
-    mov r0, EVENT_TYPE_KEY_UP
-    mov r2, 0
-    mov r3, 0
-    mov r4, 0
-    mov r5, 0
-    mov r6, 0
-    mov r7, 0
-    call new_event
-    mov r0, 0
-keyboard_update_end:
-    ret
+    jmp keyboard_update


### PR DESCRIPTION
This solves the issue of "trailing" inputs when events of a given type are arriving faster than 60 FPS, such as a user holding down a key given a fast key repeat speed.